### PR TITLE
removed purpose annotation form application mention

### DIFF
--- a/Pubmed_fulltext/PMC6411919.ann
+++ b/Pubmed_fulltext/PMC6411919.ann
@@ -99,3 +99,4 @@ T73	Purpose_Analysis 38398 38405	Cluster
 T74	Purpose_Visualization 38438 38446	TreeView
 T75	Purpose_Visualization 38544 38549	Prism
 T76	Purpose_Analysis 38582 38588	FlowJo
+T77	Purpose_Analysis 37037 37042	EdgeR


### PR DESCRIPTION
A list of files that contain both software usage and mention annotations are:

- PMC5690316.ann

- PMC7519650.ann

- PMC6411919.ann

- PMC3289918.ann

Removed the software purpose annotation from software mention annotation
